### PR TITLE
Add theme support with next-themes integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.515.0",
         "next": "^15.3.3",
+        "next-themes": "^0.4.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "tailwind-merge": "^3.3.1"
@@ -5024,6 +5025,15 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.515.0",
     "next": "^15.3.3",
+    "next-themes": "^0.4.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tailwind-merge": "^3.3.1"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css';
 import { JSX } from 'react';
 
 import { HeaderBrand } from '@/components/common/header-brand';
+import { ThemeProvider } from '@/components/theme/theme-provider';
 
 const mulish = Mulish({
   subsets: ['latin'],
@@ -42,8 +43,15 @@ export default function RootLayout({
       <body
         className={`${mulish.variable} ${raleway.variable} ${jost.variable}`}
       >
-        <HeaderBrand sticky variant="transparent" />
-        {children}
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <HeaderBrand sticky variant="transparent" />
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/common/header-brand.tsx
+++ b/src/components/common/header-brand.tsx
@@ -1,7 +1,7 @@
-import { SunIcon } from 'lucide-react';
 import Link from 'next/link';
 import { JSX } from 'react';
 
+import { ThemeToggle } from '@/components/theme/theme-toggle';
 import { headerBrand } from '@/lib/contents/header';
 import { cn } from '@/lib/utils';
 
@@ -50,12 +50,9 @@ export function HeaderBrand({
             </a>
           ))}
         </nav>
-        <button
-          aria-label="Toggle dark mode"
-          className="ml-4 p-2 rounded-full hover:bg-accent transition-colors"
-        >
-          <SunIcon className="w-6 h-6" />
-        </button>
+        <div className="ml-4">
+          <ThemeToggle />
+        </div>
       </div>
     </header>
   );

--- a/src/components/theme/theme-provider.tsx
+++ b/src/components/theme/theme-provider.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+import * as React from 'react';
+
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>): React.ReactNode {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/src/components/theme/theme-toggle.tsx
+++ b/src/components/theme/theme-toggle.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import * as React from 'react';
+
+import { Button } from '@/components/ui/button';
+
+export function ThemeToggle(): React.ReactElement {
+  const { theme, setTheme } = useTheme();
+
+  const toggleTheme = (): void => {
+    setTheme(theme === 'dark' ? 'light' : 'dark');
+  };
+
+  return (
+    <Button variant="outline" size="icon" onClick={toggleTheme}>
+      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+}


### PR DESCRIPTION
- Introduced ThemeProvider and ThemeToggle components for managing light and dark themes.
- Updated layout to include ThemeProvider for global theme management.
- Replaced manual theme toggle button with ThemeToggle component in HeaderBrand.
- Added next-themes dependency to package.json and package-lock.json.