### PR TITLE
Refactor language handling to use LanguageList enum

### DIFF
--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -6,22 +6,25 @@ import '../globals.css';
 import { HeaderBrand } from '@/components/common/header-brand';
 import { ThemeProvider } from '@/components/theme/theme-provider';
 import { getDictionary } from '@/lib/dictionaries';
+import { LanguageList } from '@/lib/types/core/language';
 
 type Props = {
-  params: Promise<{ lang: 'es' | 'en' }>;
+  params: Promise<{ lang: LanguageList }>;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { lang } = await params;
 
   const titles = {
-    es: 'Carlos Cuesta - FullStack Developer Portfolio',
-    en: 'Carlos Cuesta - FullStack Developer Portfolio',
+    [LanguageList.ES]: 'Carlos Cuesta - FullStack Developer Portfolio',
+    [LanguageList.EN]: 'Carlos Cuesta - FullStack Developer Portfolio',
   };
 
   const descriptions = {
-    es: 'Portfolio profesional de Carlos Cuesta, FullStack Developer con más de 3 años de experiencia en JavaScript, React, Node.js y TypeScript.',
-    en: 'Professional portfolio of Carlos Cuesta, FullStack Developer with 3+ years of experience in JavaScript, React, Node.js and TypeScript.',
+    [LanguageList.ES]:
+      'Portfolio profesional de Carlos Cuesta, FullStack Developer con más de 3 años de experiencia en JavaScript, React, Node.js y TypeScript.',
+    [LanguageList.EN]:
+      'Professional portfolio of Carlos Cuesta, FullStack Developer with 3+ years of experience in JavaScript, React, Node.js and TypeScript.',
   };
 
   return {
@@ -45,8 +48,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export async function generateStaticParams(): Promise<{ lang: 'es' | 'en' }[]> {
-  return [{ lang: 'es' }, { lang: 'en' }];
+export async function generateStaticParams(): Promise<
+  { lang: LanguageList }[]
+> {
+  return [{ lang: LanguageList.ES }, { lang: LanguageList.EN }];
 }
 
 export default async function RootLayout({
@@ -54,7 +59,7 @@ export default async function RootLayout({
   params,
 }: {
   children: React.ReactNode;
-  params: Promise<{ lang: 'es' | 'en' }>;
+  params: Promise<{ lang: LanguageList }>;
 }): Promise<JSX.Element> {
   const { lang } = await params;
   const dict = await getDictionary(lang);

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -8,9 +8,10 @@ import { HeroSection } from '@/components/pages/home/hero-section';
 import { ProjectsSection } from '@/components/pages/home/projects-section';
 import { SkillsSection } from '@/components/pages/home/skills-section';
 import { getDictionary } from '@/lib/dictionaries';
+import { LanguageList } from '@/lib/types/core/language';
 
 type Props = {
-  params: Promise<{ lang: 'es' | 'en' }>;
+  params: Promise<{ lang: LanguageList }>;
 };
 
 export default async function Home({ params }: Props): Promise<JSX.Element> {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,9 +8,10 @@ import { HeroSection } from '@/components/pages/home/hero-section';
 import { ProjectsSection } from '@/components/pages/home/projects-section';
 import { SkillsSection } from '@/components/pages/home/skills-section';
 import { getDictionary } from '@/lib/dictionaries';
+import { LanguageList } from '@/lib/types/core/language';
 
 type Props = {
-  params: Promise<{ lang: 'es' | 'en' }>;
+  params: Promise<{ lang: LanguageList }>;
 };
 
 export default async function Home({ params }: Props): Promise<JSX.Element> {

--- a/src/components/common/header-brand.tsx
+++ b/src/components/common/header-brand.tsx
@@ -3,6 +3,7 @@ import { JSX } from 'react';
 
 import { ThemeToggle } from '@/components/theme/theme-toggle';
 import { Dictionary } from '@/lib/dictionaries';
+import { LanguageList } from '@/lib/types/core/language';
 import { cn } from '@/lib/utils';
 
 import { LanguageSwitcher } from './language-switcher';
@@ -17,7 +18,7 @@ export function HeaderBrand({
   className?: string;
   variant?: 'default' | 'transparent' | 'bordered';
   sticky?: boolean;
-  lang: 'es' | 'en';
+  lang: LanguageList;
   dict: Dictionary;
 }): JSX.Element {
   const variantStyles: Record<string, string> = {

--- a/src/components/common/language-switcher.tsx
+++ b/src/components/common/language-switcher.tsx
@@ -11,17 +11,18 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { LanguageList } from '@/lib/types/core/language';
 
 const languages = [
-  { code: 'es', name: 'Español', flag: '🇪🇸' },
-  { code: 'en', name: 'English', flag: '🇺🇸' },
+  { code: LanguageList.ES, name: 'Español', flag: '🇪🇸' },
+  { code: LanguageList.EN, name: 'English', flag: '🇺🇸' },
 ];
 
 export function LanguageSwitcher(): JSX.Element {
   const pathname = usePathname();
   const router = useRouter();
 
-  const currentLang = pathname.split('/')[1] || 'es';
+  const currentLang = pathname.split('/')[1] || LanguageList.ES;
 
   const switchLanguage = (newLang: string): void => {
     const segments = pathname.split('/');

--- a/src/lib/dictionaries.ts
+++ b/src/lib/dictionaries.ts
@@ -1,4 +1,5 @@
 import 'server-only';
+import { LanguageList } from './types/core/language';
 
 export type Dictionary = {
   home: typeof import('./contents/es/home').homeContent;
@@ -7,9 +8,11 @@ export type Dictionary = {
 };
 
 const dictionaries = {
-  es: () => import('./contents/es').then(module => module.es),
-  en: () => import('./contents/en').then(module => module.en),
+  [LanguageList.ES]: () => import('./contents/es').then(module => module.es),
+  [LanguageList.EN]: () => import('./contents/en').then(module => module.en),
 };
 
-export const getDictionary = async (locale: 'es' | 'en'): Promise<Dictionary> =>
-  dictionaries[locale]?.() ?? dictionaries.es();
+export const getDictionary = async (
+  locale: LanguageList
+): Promise<Dictionary> =>
+  dictionaries[locale]?.() ?? dictionaries[LanguageList.ES]();

--- a/src/lib/types/core/language.ts
+++ b/src/lib/types/core/language.ts
@@ -1,0 +1,4 @@
+export enum LanguageList {
+  ES = 'es',
+  EN = 'en',
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-const locales = ['es', 'en'];
-const defaultLocale = 'es';
+import { LanguageList } from '@/lib/types/core/language';
+
+const locales = Object.values(LanguageList);
+const defaultLocale = LanguageList.ES;
 
 function getLocale(request: NextRequest): string {
   const { pathname } = request.nextUrl;
@@ -19,7 +21,7 @@ function getLocale(request: NextRequest): string {
     const preferredLocale = acceptLanguage
       .split(',')
       .map(lang => lang.split(';')[0].trim())
-      .find(lang => locales.includes(lang.split('-')[0]));
+      .find(lang => locales.includes(lang.split('-')[0] as LanguageList));
 
     if (preferredLocale) {
       return preferredLocale.split('-')[0];


### PR DESCRIPTION
- Updated middleware and components to utilize LanguageList enum for language codes.
- Changed type definitions in various components to accept LanguageList instead of string literals.
- Enhanced metadata generation and dictionary loading to support the new language structure.
- Improved language switching functionality in the HeaderBrand and LanguageSwitcher components.